### PR TITLE
Specify the type for int arguments

### DIFF
--- a/monkeytest.py
+++ b/monkeytest.py
@@ -63,16 +63,19 @@ def get_args():
     parser.add_argument('-s', '--size',
                         required=False,
                         action='store',
+                        type=int,
                         default=128,
                         help='Total MB to write')
     parser.add_argument('-w', '--write-block-size',
                         required=False,
                         action='store',
+                        type=int,
                         default=1024,
                         help='The block size for writing in bytes')
     parser.add_argument('-r', '--read-block-size',
                         required=False,
                         action='store',
+                        type=int,
                         default=512,
                         help='The block size for reading in bytes')
     parser.add_argument('-j', '--json',


### PR DESCRIPTION
Without specifying the type, argparse treats int arguments (such as `--size`) as strings when they're provided on the command line. This leads to a TypeError when they're used in calculations. For example, this fails on current master:

```
python3 monkeytest.py --size 1024
```
